### PR TITLE
Delete no longer used settinig for Armeria

### DIFF
--- a/src/main/java/info/matsumana/psystrike/config/ArmeriaConfig.java
+++ b/src/main/java/info/matsumana/psystrike/config/ArmeriaConfig.java
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 import com.linecorp.armeria.client.ClientFactory;
-import com.linecorp.armeria.common.metric.PrometheusMeterRegistries;
 import com.linecorp.armeria.server.logging.AccessLogWriter;
 import com.linecorp.armeria.server.logging.LoggingService;
 import com.linecorp.armeria.spring.AnnotatedServiceRegistrationBean;
@@ -19,12 +18,6 @@ import io.micrometer.prometheus.PrometheusMeterRegistry;
 
 @Configuration
 public class ArmeriaConfig {
-
-    @Bean
-    public PrometheusMeterRegistry prometheusMeterRegistry() {
-        // Use BetterPrometheusNamingConvention
-        return PrometheusMeterRegistries.newRegistry();
-    }
 
     @Bean
     public ClientFactory clientFactory(PrometheusMeterRegistry registry) {


### PR DESCRIPTION
Since Armeria 0.98.0, MoreNamingConventions has been deprecated

ref: https://github.com/line/armeria/releases/tag/armeria-0.98.0