### PR TITLE
Add metrics

### DIFF
--- a/psystrike/build.gradle
+++ b/psystrike/build.gradle
@@ -1,3 +1,6 @@
+// change from `psystrike-psystrike` to `psystrike`
+artifactId = 'psystrike'
+
 apply plugin: 'org.springframework.boot'
 
 dependencies {

--- a/psystrike/src/main/java/info/matsumana/psystrike/metrics/AppVersionMetricsConfig.java
+++ b/psystrike/src/main/java/info/matsumana/psystrike/metrics/AppVersionMetricsConfig.java
@@ -1,0 +1,103 @@
+package info.matsumana.psystrike.metrics;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import org.springframework.context.annotation.Configuration;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+
+@Configuration
+public class AppVersionMetricsConfig {
+
+    private static final String PROP_RESOURCE_PATH = "META-INF/info.matsumana.psystrike.versions.properties";
+    private static final String PROP_VERSION = ".version";
+    private static final String PROP_LONG_COMMIT_HASH = ".longCommitHash";
+    private static final String PROP_REPO_STATUS = ".repoStatus";
+
+    private static final class Version {
+        private final String artifactVersion;
+        private final String longCommitHash;
+        private final String repositoryStatus;
+
+        private Version(String artifactVersion, String longCommitHash, String repositoryStatus) {
+            this.artifactVersion = artifactVersion;
+            this.longCommitHash = longCommitHash;
+            this.repositoryStatus = repositoryStatus;
+        }
+    }
+
+    public AppVersionMetricsConfig(MeterRegistry meterRegistry) {
+        exportMetrics(meterRegistry);
+    }
+
+    private void exportMetrics(MeterRegistry meterRegistry) {
+        final Map<String, Version> map;
+        try {
+            map = generateVersionMap();
+        } catch (IOException ignore) {
+            return;
+        }
+
+        final Version versionInfo = map.get("psystrike");
+        final String version = versionInfo.artifactVersion;
+        final String commit = versionInfo.longCommitHash;
+        final String repositoryStatus = versionInfo.repositoryStatus;
+        final List<Tag> tags = List.of(Tag.of("version", version),
+                                       Tag.of("commit", commit),
+                                       Tag.of("repoStatus", repositoryStatus));
+        Gauge.builder("psystrike.build.info", () -> 1)
+             .tags(tags)
+             .description("A metric with a constant '1' value labeled by version and commit hash" +
+                          " from which Psystrike was built.")
+             .register(meterRegistry);
+    }
+
+    private Map<String, Version> generateVersionMap() throws IOException {
+        final Enumeration<URL> resources = getClass().getClassLoader().getResources(PROP_RESOURCE_PATH);
+
+        // Collect all properties.
+        final Properties props = new Properties();
+        while (resources.hasMoreElements()) {
+            final URL url = resources.nextElement();
+            try (InputStream in = url.openStream()) {
+                props.load(in);
+            }
+        }
+
+        // Collect all artifactIds.
+        final Set<String> artifactIds = new HashSet<>();
+        for (Object o : props.keySet()) {
+            final String k = (String) o;
+
+            final int dotIndex = k.indexOf('.');
+            if (dotIndex <= 0) {
+                continue;
+            }
+
+            final String artifactId = k.substring(0, dotIndex);
+
+            artifactIds.add(artifactId);
+        }
+
+        final Map<String, Version> versions = new HashMap<>();
+        for (String artifactId : artifactIds) {
+            versions.put(artifactId,
+                         new Version(props.getProperty(artifactId + PROP_VERSION),
+                                     props.getProperty(artifactId + PROP_LONG_COMMIT_HASH),
+                                     props.getProperty(artifactId + PROP_REPO_STATUS)));
+        }
+
+        return Map.copyOf(versions);
+    }
+}

--- a/psystrike/src/main/java/info/matsumana/psystrike/metrics/JvmVersionMetricsConfig.java
+++ b/psystrike/src/main/java/info/matsumana/psystrike/metrics/JvmVersionMetricsConfig.java
@@ -1,0 +1,28 @@
+package info.matsumana.psystrike.metrics;
+
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+
+@Configuration
+public class JvmVersionMetricsConfig {
+
+    public JvmVersionMetricsConfig(@Value("${java.vm.vendor}") String vmVendor,
+                                   @Value("${java.vm.version}") String vmVersion,
+                                   @Value("${java.version}") String version,
+                                   MeterRegistry meterRegistry) {
+        final List<Tag> tags = List.of(Tag.of("vmVendor", vmVendor),
+                                       Tag.of("vmVersion", vmVersion),
+                                       Tag.of("version", version));
+        Gauge.builder("jvm.build.info", () -> 1)
+             .tags(tags)
+             .description("A metric with a constant '1' value labeled by version"
+                          + " from which JVM is used by the app.")
+             .register(meterRegistry);
+    }
+}

--- a/psystrike/src/main/java/info/matsumana/psystrike/metrics/SpringVersionMetricsConfig.java
+++ b/psystrike/src/main/java/info/matsumana/psystrike/metrics/SpringVersionMetricsConfig.java
@@ -1,0 +1,24 @@
+package info.matsumana.psystrike.metrics;
+
+import java.util.List;
+
+import org.springframework.boot.SpringBootVersion;
+import org.springframework.context.annotation.Configuration;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+
+@Configuration
+public class SpringVersionMetricsConfig {
+
+    public SpringVersionMetricsConfig(MeterRegistry meterRegistry) {
+        final String version = SpringBootVersion.getVersion();
+        final List<Tag> tags = List.of(Tag.of("version", version));
+        Gauge.builder("spring.boot.build.info", () -> 1)
+             .tags(tags)
+             .description("A metric with a constant '1' value labeled by version"
+                          + " from which Spring Boot is used by the app.")
+             .register(meterRegistry);
+    }
+}

--- a/psystrike/src/main/java/info/matsumana/psystrike/service/ReverseProxyService.java
+++ b/psystrike/src/main/java/info/matsumana/psystrike/service/ReverseProxyService.java
@@ -45,13 +45,13 @@ import hu.akarnokd.rxjava2.interop.ObservableInterop;
 import info.matsumana.psystrike.config.KubernetesProperties;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
 import io.netty.util.AsciiString;
-import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 @Component
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Slf4j
 public class ReverseProxyService {
 


### PR DESCRIPTION
e.g.

```
# HELP spring_boot_build_info A metric with a constant '1' value labeled by version from which Spring Boot is used by the app.
# TYPE spring_boot_build_info gauge
spring_boot_build_info{version="2.2.6.RELEASE",} 1.0

# HELP jvm_build_info A metric with a constant '1' value labeled by version from which JVM is used by the app.
# TYPE jvm_build_info gauge
jvm_build_info{version="11.0.7",vmVendor="AdoptOpenJDK",vmVersion="11.0.7+10",} 1.0

# HELP psystrike_build_info A metric with a constant '1' value labeled by version and commit hash from which Psystrike was built.
# TYPE psystrike_build_info gauge
psystrike_build_info{commit="1b1a7db163156d1ab562f74bc951d24a1a111ade",repoStatus="dirty",version="0.5.2-SNAPSHOT",} 1.0
```